### PR TITLE
URL Cleanup

### DIFF
--- a/dockerfiles/dotnet/Dockerfile
+++ b/dockerfiles/dotnet/Dockerfile
@@ -3,8 +3,8 @@ FROM microsoft/dotnet:latest
 RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&source=github' | tar -zx -C /usr/local/bin/
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
- && echo "deb http://download.mono-project.com/repo/debian wheezy-libjpeg62-compat main" | tee -a /etc/apt/sources.list.d/mono-xamarin.list \
- && echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/4.4.2.11 main" | tee -a /etc/apt/sources.list.d/mono-xamarin.list \
+ && echo "deb https://download.mono-project.com/repo/debian wheezy-libjpeg62-compat main" | tee -a /etc/apt/sources.list.d/mono-xamarin.list \
+ && echo "deb https://download.mono-project.com/repo/debian wheezy/snapshots/4.4.2.11 main" | tee -a /etc/apt/sources.list.d/mono-xamarin.list \
  && apt-get update \
  && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
  && (apt-get install --fix-missing -y mono-devel vim nodejs || apt-get install --fix-missing -y mono-devel vim nodejs) \


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://download.mono-project.com/repo/debian with 2 occurrences migrated to:  
  https://download.mono-project.com/repo/debian ([https](https://download.mono-project.com/repo/debian) result 301).